### PR TITLE
implement express interest frontend

### DIFF
--- a/frontend/src/components/Post/Modals/InterestConfirmationDialog.css
+++ b/frontend/src/components/Post/Modals/InterestConfirmationDialog.css
@@ -1,0 +1,90 @@
+.dialog-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.dialog-box {
+  background: white;
+  width: 90%;
+  max-width: 500px;
+  padding: 20px;
+  border-radius: 10px;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.2);
+}
+
+.dialog-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.icon-mail {
+  width: 24px;
+  height: 24px;
+  color: #0077cc;
+}
+
+.dialog-description {
+  font-size: 15px;
+  line-height: 1.5;
+  color: #444;
+}
+
+.dialog-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 24px;
+}
+
+.cancel-btn-dialog {
+  padding: 8px 16px;
+  font-size: 14px;
+  border-radius: 6px;
+  border: none;
+  cursor: pointer;
+  background: #e0e0e0;
+  color: #333;
+}
+
+.confirm-btn-dialog {
+  padding: 8px 16px;
+  font-size: 14px;
+  border-radius: 6px;
+  border: none;
+  cursor: pointer;
+  background: #ff7a00;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.confirm-btn-dialog.disabled {
+  background: #ffa94d;
+  cursor: not-allowed;
+}
+
+.icon,
+.loader {
+  width: 16px;
+  height: 16px;
+}
+
+.loader {
+  animation: spin 1s linear infinite;
+}
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/frontend/src/components/Post/Modals/InterestConfirmationDialog.jsx
+++ b/frontend/src/components/Post/Modals/InterestConfirmationDialog.jsx
@@ -1,0 +1,86 @@
+import './InterestConfirmationDialog.css';
+import { useState } from 'react';
+import { MdOutlineEmail } from 'react-icons/md';
+import { FiLoader } from 'react-icons/fi';
+const InterestConfirmationDialog = ({
+  post,
+  open,
+  onOpenChange,
+  setShowToast,
+  setShowModal,
+}) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState(null);
+
+  const handleConfirm = async () => {
+    setIsLoading(true);
+    try {
+      // [TODO] email to the user
+      onOpenChange(false);
+    } catch (error) {
+      console.error(error);
+      setErrorMessage(error.message);
+    } finally {
+      setShowModal(false);
+      setShowToast(true);
+      setIsLoading(false);
+    }
+  };
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="dialog-overlay">
+      <div className="dialog-box">
+        <div className="dialog-header">
+          <MdOutlineEmail className="icon-mail" />
+          <h2>Express Interest</h2>
+        </div>
+        <p className="dialog-description">
+          Are you sure you want to express interest in{' '}
+          <strong>{post.title}</strong>?
+          <br />
+          <br />
+          An email will be sent to <strong>{post.user.first_name}</strong> with
+          your contact information.
+        </p>
+        <div className="dialog-footer">
+          <button
+            className="cancel-btn-dialog"
+            onClick={() => onOpenChange(false)}
+            disabled={isLoading}
+          >
+            Cancel
+          </button>
+          <button
+            className="confirm-btn-dialog"
+            onClick={handleConfirm}
+            disabled={isLoading}
+          >
+            {isLoading ? (
+              <>
+                <FiLoader className="loader" />
+                Sending...
+              </>
+            ) : (
+              <>
+                <MdOutlineEmail className="icon" />
+                Send Interest
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+      {errorMessage && (
+        <ErrorModal
+          errorMessage={errorMessage}
+          setErrorMessage={setErrorMessage}
+        />
+      )}
+    </div>
+  );
+};
+
+export default InterestConfirmationDialog;

--- a/frontend/src/components/Post/Modals/PostInfoModal.jsx
+++ b/frontend/src/components/Post/Modals/PostInfoModal.jsx
@@ -5,10 +5,28 @@ import { IoMdClose } from 'react-icons/io';
 import ReviewContainer from '../../Reviews/ReviewContainer';
 import { HiOutlineMail } from 'react-icons/hi';
 import { fetchPostReviews } from '../../../utils/reviewFetch';
+import InterestConfirmationDialog from './InterestConfirmationDialog';
 
-const PostInfoModal = ({ post,setReviewCount, onClose }) => {
+const PostInfoModal = ({
+  post,
+  setReviewCount,
+  onClose,
+  setShowToast,
+  setShowModal,
+}) => {
   const [reviews, setReviews] = useState([]);
   const [isReviewOpen, setIsReviewOpen] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const handleSendInterest = async () => {
+    //TODO: Send interest to the server
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    setShowToast(true);
+  };
+
+  const handleSchedule = () => {
+    //TODO: Schedule a session with the owner of the post
+  };
 
   const handleReviewClick = async () => {
     if (!isReviewOpen) {
@@ -23,7 +41,7 @@ const PostInfoModal = ({ post,setReviewCount, onClose }) => {
   };
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
+    <div className="modal-overlay">
       <div className="modal-content" onClick={(e) => e.stopPropagation()}>
         <button id="close-btn" onClick={onClose}>
           <IoMdClose />
@@ -42,7 +60,6 @@ const PostInfoModal = ({ post,setReviewCount, onClose }) => {
               alt={post.title}
             />
           </div>
-
           <div>
             <h3>Description</h3>
             <p>{post.description}</p>
@@ -64,7 +81,12 @@ const PostInfoModal = ({ post,setReviewCount, onClose }) => {
         </div>
 
         <div className="review-interest-section">
-          <button className="interest-btn">
+          <button
+            className="interest-btn"
+            onClick={() => {
+              setDialogOpen(true);
+            }}
+          >
             <HiOutlineMail className="email-icon" /> Express interest
           </button>
           <div className="modal-reviews-section">
@@ -83,6 +105,14 @@ const PostInfoModal = ({ post,setReviewCount, onClose }) => {
           />
         )}
       </div>
+      <InterestConfirmationDialog
+        post={post}
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        onConfirm={handleSendInterest}
+        setShowToast={setShowToast}
+        setShowModal={setShowModal}
+      />
     </div>
   );
 };

--- a/frontend/src/components/Post/PostCard.jsx
+++ b/frontend/src/components/Post/PostCard.jsx
@@ -7,6 +7,7 @@ import { FaHeart } from 'react-icons/fa6';
 import { FaRegHeart } from 'react-icons/fa6';
 import { interactionLog } from '../../utils/recommendationFetch';
 import { InteractionTypes } from '../../utils/InteractionTypes';
+import EmailToast from '../schedule/EmailToast';
 
 function PostCard({ post, posts }) {
   const [likes, setLikes] = useState(post.numLikes);
@@ -21,6 +22,7 @@ function PostCard({ post, posts }) {
   const [showRecommend, setShowRecommend] = useState(false);
   const request = 'REQUEST';
   const offer = 'OFFER';
+  const [showToast, setShowToast] = useState(false);
 
   const handlePostClick = async (e) => {
     e.preventDefault();
@@ -120,8 +122,10 @@ function PostCard({ post, posts }) {
       {showModal && post.type == offer && (
         <PostInfoModal
           setReviewCount={setReviewCount}
+          setShowModal={setShowModal}
           post={post}
           onClose={onClose}
+          setShowToast={setShowToast}
         />
       )}
 
@@ -135,6 +139,7 @@ function PostCard({ post, posts }) {
           }}
         />
       )}
+      {showToast && <EmailToast post={post} setShowToast={setShowToast} />}
     </>
   );
 }

--- a/frontend/src/components/schedule/EmailToast.css
+++ b/frontend/src/components/schedule/EmailToast.css
@@ -1,0 +1,66 @@
+.toast {
+  position: relative;
+  background: #1a1a1a;
+  color: #fff;
+  padding: 16px 20px;
+  border-radius: 8px;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.2);
+  text-align: left;
+  max-width: 320px;
+}
+
+.schedule-btn {
+  margin-top: 10px;
+  background: #ffffff;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  padding: 6px 14px;
+  font-size: 14px;
+  cursor: pointer;
+  color: #1a1a1a;
+}
+
+.toast strong {
+  color: #ffb347;
+}
+
+.toast-wrapper {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.close-toast {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  cursor: pointer;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 20px;
+}
+
+.close-toast:hover {
+  opacity: 0.8;
+  background-color: #ccc;
+}
+
+@keyframes pulse-glow {
+  0% {
+    box-shadow: 0 0 0 0px rgba(6, 0, 1, 0.5);
+  }
+  50% {
+    box-shadow: 0 0 0 10px rgba(4, 0, 1, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(8, 0, 0, 0);
+  }
+}
+.toast.pulse {
+  animation: pulse-glow 1s infinite;
+}

--- a/frontend/src/components/schedule/EmailToast.jsx
+++ b/frontend/src/components/schedule/EmailToast.jsx
@@ -1,0 +1,28 @@
+import './EmailToast.css';
+import { IoMdClose } from 'react-icons/io';
+const EmailToast = ({ post, setShowToast }) => {
+  return (
+    <div className="toast-wrapper">
+      <div className="toast pulse">
+        <button className="close-toast" onClick={() => setShowToast(false)}>
+          <IoMdClose />
+        </button>
+        <p>
+          Your interest has been sent to <strong>{post.user.first_name}</strong>
+          . You can expect to hear back from them soon.
+        </p>
+        <button
+          className="schedule-btn"
+          onClick={() => {
+            setShowToast(false);
+            handleSchedule();
+          }}
+        >
+          Schedule Session
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default EmailToast;


### PR DESCRIPTION


## Description

This pull request focuses on the frontend features related to the "Express Interest" functionality. Specifically, it includes:
**Addition of a Confirmation Modal:** A modal will pop up to confirm when a user expresses interest in a post.
**Implementation of a Toast Message:** A notification toast will appear, featuring a button that allows users to schedule a session.

## Future Work

Please note that the backend setup for sending emails via Nodemailer will be addressed in future pull requests and is not included in this one.

## Milestones
Enable users to express interest by sending an email containing their contact details.

## Resources
https://react-icons.github.io/react-icons/

## Test Plan
The flow of navigation was tested on the UI. Here is a demo video: https://pxl.cl/7KnL4

