### PR TITLE
implement route for sending email to post owners

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -11,6 +11,7 @@ const likeRoutes = require('./routes/likes');
 const profileRoutes = require('./routes/profile');
 const recommendationRoutes = require('./routes/recommendation');
 const { router: searchRoutes } = require('./routes/search');
+const emailRoutes = require('./routes/email');
 const fileUpload = require('express-fileupload');
 const app = express();
 
@@ -60,6 +61,7 @@ app.use('/like', likeRoutes);
 app.use('/profile', profileRoutes);
 app.use('/search', searchRoutes);
 app.use('/recommendation', recommendationRoutes);
+app.use('/email', emailRoutes);
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -21,7 +21,9 @@
         "express-session": "^1.18.1",
         "fuse.js": "^7.1.0",
         "morgan": "^1.10.0",
+        "nodemailer": "^7.0.5",
         "pg": "^8.16.2",
+        "resend": "^4.7.0",
         "streamifier": "^0.1.1"
       },
       "devDependencies": {
@@ -48,6 +50,37 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-email/render": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@react-email/render/-/render-1.1.2.tgz",
+      "integrity": "sha512-RnRehYN3v9gVlNMehHPHhyp2RQo7+pSkHDtXPvg3s0GbzM9SQMW4Qrf8GRNvtpLC4gsI+Wt0VatNRUFqjvevbw==",
+      "license": "MIT",
+      "dependencies": {
+        "html-to-text": "^9.0.5",
+        "prettier": "^3.5.3",
+        "react-promise-suspense": "^0.3.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@selderee/plugin-htmlparser2": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "selderee": "^0.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/accepts": {
@@ -258,6 +291,15 @@
         }
       }
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -265,6 +307,61 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dotenv": {
@@ -306,6 +403,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -462,6 +571,12 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
@@ -588,6 +703,41 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-to-text": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@selderee/plugin-htmlparser2": "^0.11.0",
+        "deepmerge": "^4.3.1",
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^8.0.2",
+        "selderee": "^0.11.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -645,6 +795,15 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/leac": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
     },
     "node_modules/lodash": {
       "version": "4.17.21",
@@ -781,6 +940,15 @@
         "node-gyp-build-test": "build-test.js"
       }
     },
+    "node_modules/nodemailer": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.5.tgz",
+      "integrity": "sha512-nsrh2lO3j4GkLLXoeEksAMgAOqxOv6QumNRVQTJwKH4nuiww6iC2y7GyANs9kRAxCexg3+lTWM3PZ91iLlVjfg==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -832,6 +1000,19 @@
         "wrappy": "1"
       }
     },
+    "node_modules/parseley": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+      "license": "MIT",
+      "dependencies": {
+        "leac": "^0.6.0",
+        "peberminta": "^0.9.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -848,6 +1029,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/peberminta": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/pg": {
@@ -982,7 +1172,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -1066,6 +1255,50 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/react": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
+      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.26.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-promise-suspense": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/react-promise-suspense/-/react-promise-suspense-0.3.4.tgz",
+      "integrity": "sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^2.0.1"
+      }
+    },
+    "node_modules/resend": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-4.7.0.tgz",
+      "integrity": "sha512-30IbXGBUbmDweQH2IlO53XOXX7ndjYV9xFZ8IEBiWqefqQ/qmTsgrX0Ab6MUnmobJXbpdReVv+iXGRQPubQL5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-email/render": "1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -1107,6 +1340,25 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/selderee": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+      "license": "MIT",
+      "dependencies": {
+        "parseley": "^0.12.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
     },
     "node_modules/send": {
       "version": "1.2.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,7 +26,9 @@
     "express-session": "^1.18.1",
     "fuse.js": "^7.1.0",
     "morgan": "^1.10.0",
+    "nodemailer": "^7.0.5",
     "pg": "^8.16.2",
+    "resend": "^4.7.0",
     "streamifier": "^0.1.1"
   },
   "devDependencies": {

--- a/backend/routes/email.js
+++ b/backend/routes/email.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const router = express.Router();
+const { sendEmail } = require('../services/email/mailer');
+const checkAuth = require('../middleware/checkAuth');
+
+router.post('/send', checkAuth, async (req, res) => {
+  const { to, skillTitle, senderName } = req.body;
+  const senderEmail = req.session.email;
+  if (!to || !skillTitle) {
+    return res.status(400).json({ message: 'Missing required fields' });
+  }
+
+  try {
+    await sendEmail({ to, senderName, senderEmail, skillTitle });
+    res.status(200).json({ message: 'Email sent successfully' });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: 'Error sending email' });
+  }
+});
+
+module.exports = router;

--- a/backend/routes/email.js
+++ b/backend/routes/email.js
@@ -2,20 +2,22 @@ const express = require('express');
 const router = express.Router();
 const { sendEmail } = require('../services/email/mailer');
 const checkAuth = require('../middleware/checkAuth');
+const ERROR_CODES = require('../utils/errors');
+const MESSAGES = require('../utils/messages');
 
 router.post('/send', checkAuth, async (req, res) => {
   const { to, skillTitle, senderName } = req.body;
   const senderEmail = req.session.email;
   if (!to || !skillTitle) {
-    return res.status(400).json({ message: 'Missing required fields' });
+    return res.status(400).json({ error: ERROR_CODES.MISSING_FIELDS });
   }
 
   try {
     await sendEmail({ to, senderName, senderEmail, skillTitle });
-    res.status(200).json({ message: 'Email sent successfully' });
+    res.status(200).json({ message: MESSAGES.EMAIL_SENT });
   } catch (error) {
     console.error(error);
-    res.status(500).json({ message: 'Error sending email' });
+    res.status(500).json({ error: ERROR_CODES.EMAIL_SEND_FAILED });
   }
 });
 

--- a/backend/services/email/mailer.js
+++ b/backend/services/email/mailer.js
@@ -1,0 +1,23 @@
+const nodemailer = require('nodemailer');
+require('dotenv').config();
+
+async function sendEmail({ to, senderName, senderEmail, skillTitle }) {
+  const transporter = nodemailer.createTransport({
+    service: 'gmail',
+    auth: {
+      user: process.env.EMAIL_USER,
+      pass: process.env.EMAIL_PASS,
+    },
+  });
+
+  await transporter.sendMail({
+    from: `"SkillSwap" <${process.env.EMAIL_USER}>`,
+    to,
+    subject: `Interest in your "${skillTitle}" post`,
+    html: `<p><strong>${senderName}</strong> is interested in your <em>${skillTitle}</em> post.</p> <p>Send them a message at <strong>${senderEmail}</strong> to get in touch.</p>`,
+  });
+
+  console.log(' Email sent via Gmail');
+}
+
+module.exports = { sendEmail };

--- a/backend/services/email/mailer.js
+++ b/backend/services/email/mailer.js
@@ -16,8 +16,6 @@ async function sendEmail({ to, senderName, senderEmail, skillTitle }) {
     subject: `Interest in your "${skillTitle}" post`,
     html: `<p><strong>${senderName}</strong> is interested in your <em>${skillTitle}</em> post.</p> <p>Send them a message at <strong>${senderEmail}</strong> to get in touch.</p>`,
   });
-
-  console.log(' Email sent via Gmail');
 }
 
 module.exports = { sendEmail };

--- a/backend/utils/errors.js
+++ b/backend/utils/errors.js
@@ -25,6 +25,7 @@ const ERROR_CODES = {
   ERROR_INITIALIZING_TRIE: 'Error initializing trie',
   INVALID_REQUEST: 'Invalid request',
   MISSING_INTERESTS: 'Missing interests',
+  EMAIL_SEND_FAILED: 'Error sending email',
 };
 
 module.exports = ERROR_CODES;

--- a/backend/utils/messages.js
+++ b/backend/utils/messages.js
@@ -1,0 +1,5 @@
+const MESSAGES = {
+  EMAIL_SENT: 'Email sent successfully',
+};
+
+module.exports = MESSAGES;

--- a/frontend/src/components/Post/Modals/InterestConfirmationDialog.jsx
+++ b/frontend/src/components/Post/Modals/InterestConfirmationDialog.jsx
@@ -8,6 +8,7 @@ const InterestConfirmationDialog = ({
   onOpenChange,
   setShowToast,
   setShowModal,
+  onConfirm,
 }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState(null);
@@ -16,6 +17,7 @@ const InterestConfirmationDialog = ({
     setIsLoading(true);
     try {
       // [TODO] email to the user
+      await onConfirm();
       onOpenChange(false);
     } catch (error) {
       console.error(error);


### PR DESCRIPTION
## Description

This PR introduces backend email functionality using the Gmail SMTP service integrated via Nodemailer. It allows the app to send email notifications when a user expresses interest in a skill post.

Configured Gmail SMTP transport via Nodemailer.

Added POST /api/send-interest route to index.js.

Emails are currently sent from a verified Gmail address (via .env).

What's not included (to be done later):
Integration with frontend Express Interest action
Unit tests or error handling improvements


## Milestones
✅ Backend: Email notifications MVP
🟡 Connect frontend → backend trigger (coming next)

## Resources
Nodemailer Docs
Gmail SMTP Config
App Passwords (Gmail)

## Test Plan
Here is a sample email sent to a test user: 
<img width="1176" height="472" alt="Screenshot 2025-07-18 at 4 31 36 PM" src="https://github.com/user-attachments/assets/c14a8b33-8c75-463a-91a8-487df4d45de8" />
Tests on insomia: 
<img width="1225" height="272" alt="Screenshot 2025-07-18 at 4 34 35 PM" src="https://github.com/user-attachments/assets/d11c1268-81c6-4f09-99bd-2b3ea645ea9e" />

