### PR TITLE
integrate backend email sending with frontend

### DIFF
--- a/backend/routes/post.js
+++ b/backend/routes/post.js
@@ -21,7 +21,7 @@ router.get('/', async (req, res) => {
       where: filters,
       include: {
         user: {
-          select: { id: true, first_name: true, last_name: true },
+          select: { id: true, first_name: true, last_name: true, email: true },
         },
         reviews: true,
         likes: true,

--- a/frontend/src/components/Post/Modals/InterestConfirmationDialog.jsx
+++ b/frontend/src/components/Post/Modals/InterestConfirmationDialog.jsx
@@ -2,33 +2,16 @@ import './InterestConfirmationDialog.css';
 import { useState } from 'react';
 import { MdOutlineEmail } from 'react-icons/md';
 import { FiLoader } from 'react-icons/fi';
+import ErrorModal from '../../ErrorModal';
 const InterestConfirmationDialog = ({
   post,
   open,
   onOpenChange,
-  setShowToast,
-  setShowModal,
   onConfirm,
+  errorMessage,
+  setErrorMessage,
+  isLoading,
 }) => {
-  const [isLoading, setIsLoading] = useState(false);
-  const [errorMessage, setErrorMessage] = useState(null);
-
-  const handleConfirm = async () => {
-    setIsLoading(true);
-    try {
-      // [TODO] email to the user
-      await onConfirm();
-      onOpenChange(false);
-    } catch (error) {
-      console.error(error);
-      setErrorMessage(error.message);
-    } finally {
-      setShowModal(false);
-      setShowToast(true);
-      setIsLoading(false);
-    }
-  };
-
   if (!open) {
     return null;
   }
@@ -58,7 +41,7 @@ const InterestConfirmationDialog = ({
           </button>
           <button
             className="confirm-btn-dialog"
-            onClick={handleConfirm}
+            onClick={onConfirm}
             disabled={isLoading}
           >
             {isLoading ? (

--- a/frontend/src/components/Post/Modals/PostInfoModal.jsx
+++ b/frontend/src/components/Post/Modals/PostInfoModal.jsx
@@ -6,6 +6,7 @@ import ReviewContainer from '../../Reviews/ReviewContainer';
 import { HiOutlineMail } from 'react-icons/hi';
 import { fetchPostReviews } from '../../../utils/reviewFetch';
 import InterestConfirmationDialog from './InterestConfirmationDialog';
+import { sendEmail } from '../../../utils/emailFetch';
 
 const PostInfoModal = ({
   post,
@@ -17,11 +18,24 @@ const PostInfoModal = ({
   const [reviews, setReviews] = useState([]);
   const [isReviewOpen, setIsReviewOpen] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
 
   const handleSendInterest = async () => {
-    //TODO: Send interest to the server
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    setShowToast(true);
+    setIsLoading(true);
+    try {
+      const senderName = `${post.user.first_name} ${post.user.last_name}`;
+      const skillTitle = post.title;
+      const to = post.user.email;
+      await sendEmail(to, senderName, skillTitle);
+      setDialogOpen(false);
+      setShowToast(true);
+    } catch (error) {
+      setErrorMessage(error.message);
+      console.error(error);
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   const handleSchedule = () => {
@@ -112,6 +126,10 @@ const PostInfoModal = ({
         onConfirm={handleSendInterest}
         setShowToast={setShowToast}
         setShowModal={setShowModal}
+        errorMessage={errorMessage}
+        setErrorMessage={setErrorMessage}
+        isLoading={isLoading}
+        setIsLoading={setIsLoading}
       />
     </div>
   );

--- a/frontend/src/utils/ErrorCodes.js
+++ b/frontend/src/utils/ErrorCodes.js
@@ -12,4 +12,5 @@ export const ERROR_CODES = {
   ERROR_UPDATING_PROFILE_PICTURE: 'Error updating profile picture',
   ERROR_FETCHING_TOKENIZED_SEARCH: 'Error fetching search results',
   ERROR_FETCHING_RECOMMENDATIONS: 'Error fetching recommendations',
+  EMAIL_SEND_FAILED: 'Email send failed',
 };

--- a/frontend/src/utils/apiRoutes.js
+++ b/frontend/src/utils/apiRoutes.js
@@ -20,4 +20,5 @@ export const API_ROUTES = {
   tokenizedSearch: `${BASE_URL}/search`,
   interaction: `${BASE_URL}/recommendation/interaction`,
   recommendations: `${BASE_URL}/recommendation`,
+  email: `${BASE_URL}/email`,
 };

--- a/frontend/src/utils/emailFetch.js
+++ b/frontend/src/utils/emailFetch.js
@@ -1,0 +1,27 @@
+import { API_ROUTES } from './apiRoutes';
+import { ERROR_CODES } from './ErrorCodes';
+
+export const sendEmail = async (to, skillTitle, senderName) => {
+  try {
+    const url = `${API_ROUTES.email}/send`;
+    const data = {
+      to,
+      skillTitle,
+      senderName,
+    };
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      credentials: 'include',
+      body: JSON.stringify(data),
+    });
+    if (!response.ok) {
+      throw new Error(ERROR_CODES.EMAIL_SEND_FAILED);
+    }
+    return await response.json();
+  } catch (error) {
+    throw new Error(error);
+  }
+};


### PR DESCRIPTION

## Description
**What this pull request is doing:**

Added error handling using errorModal.
Added emailFetch utility for fetching backend data.

**What will be done in later PRs and not included here:**
Implement scheduling functionality for the app. After the confirmation toast appears, users will be able to schedule a session with the post owner.

## Milestones
Users can send emails to post owners with their contact details and handle communication via email.

## Resources
n/a

## Test Plan
Demo video: https://pxl.cl/7KnL4
Verified email sending by checking the Gmail app for sent emails.
Tested error handling by using a broken route; confirmed that the error modal appears as expected.
