### PR TITLE
 add utils for distance calculation

### DIFF
--- a/backend/services/search/geo.js
+++ b/backend/services/search/geo.js
@@ -1,0 +1,57 @@
+import dotenv from 'dotenv';
+dotenv.config();
+/**
+ *  Geo.js - A utility for getting coordinates from a location
+ * @param {*} location - The location to get coordinates for
+ * @returns - The coordinates of the location as an object with latitude and longitude properties
+ */
+
+export async function getCoordinates(location) {
+  const apiKey = process.env.GEOAPIFY_API_KEY;
+  const url = `https://api.geoapify.com/v1/geocode/search?text=${encodeURIComponent(location)}&format=json&apiKey=${apiKey}`;
+
+  try {
+    const response = await fetch(url);
+    const data = await response.json();
+    const result = data?.results[0];
+    if (!result) {
+      return null;
+    }
+    return {
+      latitude: result.lat,
+      longitude: result.lon,
+    };
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+}
+
+/**
+ *  HarvesineDistance.js - A utility for calculating the distance between two coordinates using the Harvesine formula
+ * @param {*} lat1 - The latitude of the first coordinate
+ * @param {*} lon1 - The longitude of the first coordinate
+ * @param {*} lat2 - The latitude of the second coordinate
+ * @param {*} lon2 - The longitude of the second coordinate
+ * @returns
+ */
+
+export function harvesineDistance(lat1, lon1, lat2, lon2) {
+  const toRadian = (value) => (value * Math.PI) / 180;
+  const R = 6371; // Radius of the Earth in kilometers
+
+  const dLat = toRadian(lat2 - lat1);
+  const dLon = toRadian(lon2 - lon1);
+
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRadian(lat1)) *
+      Math.cos(toRadian(lat2)) *
+      Math.sin(dLon / 2) *
+      Math.sin(dLon / 2);
+
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  const distance = R * c;
+
+  return distance;
+}

--- a/backend/tests/geoTests.js
+++ b/backend/tests/geoTests.js
@@ -1,0 +1,25 @@
+//test for geo.js
+
+const { getCoordinates, harvesineDistance } = require('../services/search/geo');
+
+(async () => {
+  console.log('Starting geo tests');
+
+  Promise.all([getCoordinates('Menlo Park'), getCoordinates('San Francisco')])
+    .then((results) => {
+      const loc1 = results[0];
+      const loc2 = results[1];
+      console.log('Menlo Park', loc1);
+      console.log('San Francisco', loc2);
+      const distance = harvesineDistance(
+        loc1.latitude,
+        loc1.longitude,
+        loc2.latitude,
+        loc2.longitude
+      );
+      console.log('Distance', distance, 'km');
+    })
+    .catch((err) => {
+      console.log('Error', err);
+    });
+})();


### PR DESCRIPTION
# feat(geo): fetch coordinates & calculate distances

## What This PR Does

This pull request introduces foundational geolocation utilities to enable future location-aware features (e.g., location-based search or recommendations):

* **Geoapify Integration**  
  * Added utility to fetch `{ lat, lon }` coordinates from a string location (e.g., "Menlo Park") using Geoapify’s geocoding API.

*  **Distance Calculation (Haversine Formula)**  
  * Implemented the Haversine formula to calculate the distance between two geographic coordinates in kilometers.

*  **Testing Utilities**  
  * Added a test script in `tests/` that manually checks both coordinate fetching and distance logic.

---

##  What’s Coming in Later PRs

* Integrate distance scoring into the recommendation engine  
* Enhance post ranking based on proximity.


---

##  Milestones

* [x] Location-aware utilities foundation  

---

## Resources

*  Geoapify Geocoding API → https://apidocs.geoapify.com  
*  Haversine Formula Reference → [Wikipedia](https://en.wikipedia.org/wiki/Haversine_formula)  
---

##  Test Plan

* **Manual test script added** in `tests/testGeo.js`
* Verified the following flow:
  * Convert `"Menlo Park"` and `"San Francisco"` into coordinates
  * Log output
  * Calculate and print distance
*  Output confirmed accurate using external map tools (e.g., Google Maps)
* Edge case considered:
  * Location not found
  * Invalid input (e.g., empty string)
