### PR TITLE
work on Tc#1/iteration PRs feedback

### DIFF
--- a/backend/services/search/geo.js
+++ b/backend/services/search/geo.js
@@ -37,7 +37,10 @@ export async function getCoordinates(location, type = 'post') {
   try {
     const response = await fetch(url);
     const data = await response.json();
-    const result = data?.results[0];
+    const result =
+      Array.isArray(data?.results) && data.results.length > 0
+        ? data?.results[0]
+        : null;
     if (!result) {
       return null;
     }

--- a/backend/tests/geoTests.js
+++ b/backend/tests/geoTests.js
@@ -1,25 +1,36 @@
 //test for geo.js
-
 const { getCoordinates, harvesineDistance } = require('../services/search/geo');
 
 (async () => {
   console.log('Starting geo tests');
 
-  Promise.all([getCoordinates('Menlo Park'), getCoordinates('San Francisco')])
-    .then((results) => {
-      const loc1 = results[0];
-      const loc2 = results[1];
-      console.log('Menlo Park', loc1);
-      console.log('San Francisco', loc2);
-      const distance = harvesineDistance(
-        loc1.latitude,
-        loc1.longitude,
-        loc2.latitude,
-        loc2.longitude
-      );
-      console.log('Distance', distance, 'km');
-    })
-    .catch((err) => {
-      console.log('Error', err);
-    });
+  try {
+    const [loc1, loc2] = await Promise.all([
+      getCoordinates('Menlo Park'),
+      getCoordinates('San Francisco'),
+    ]);
+
+    if (!loc1 || !loc2) {
+      console.log('Error: could not get coordinates');
+      return;
+    }
+    const distance = harvesineDistance(
+      loc1.latitude,
+      loc1.longitude,
+      loc2.latitude,
+      loc2.longitude
+    );
+    console.log('Distance', distance, 'km');
+
+    const expected = 45.0;
+    const tolerance = 5;
+
+    if (Math.abs(distance - expected) <= tolerance) {
+      console.log('Test passed');
+    } else {
+      console.log('Test failed');
+    }
+  } catch (err) {
+    console.log('Error', err);
+  }
 })();

--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -8,6 +8,7 @@ import { getRecommendations } from '../utils/recommendationFetch';
 import Loading from '../components/Loading/Loading';
 import './LandingPage.css';
 import { FaArrowRight } from 'react-icons/fa';
+import { filterByRecency } from '../utils/postFilters';
 
 const LandingPage = () => {
   const [filter, setFilter] = useState('Recommended');
@@ -42,20 +43,7 @@ const LandingPage = () => {
 
   const filteredPosts = posts.filter((post) => {
     const matchType = type ? post.type === type : true;
-    const matchRecency = recency
-      ? (() => {
-          const createdAt = new Date(post.createdAt);
-          const now = new Date();
-          if (recency === 'last_week') {
-            const oneWeekAgo = new Date(now.setDate(now.getDate() - 7));
-            return createdAt > oneWeekAgo;
-          } else if (recency === 'last_month') {
-            const oneMonthAgo = new Date(now.setMonth(now.getMonth() - 1));
-            return createdAt > oneMonthAgo;
-          }
-          return true;
-        })()
-      : true;
+    const matchRecency = filterByRecency(post, recency);
     return matchType && matchRecency;
   });
 

--- a/frontend/src/utils/postFilters.js
+++ b/frontend/src/utils/postFilters.js
@@ -1,0 +1,22 @@
+export function filterByRecency(post, recency) {
+  if (!recency) {
+    return true;
+  }
+  const createdAt = new Date(post.createdAt);
+  const now = new Date();
+
+  switch (recency) {
+    case 'last_week': {
+      const oneWeekAgo = new Date(now);
+      oneWeekAgo.setDate(now.getDate() - 7);
+      return createdAt > oneWeekAgo;
+    }
+    case 'last_month': {
+      const oneMonthAgo = new Date(now);
+      oneMonthAgo.setMonth(now.getMonth() - 1);
+      return createdAt > oneMonthAgo;
+    }
+    default:
+      return true;
+  }
+}


### PR DESCRIPTION
#  Refactor: Filter Utils + Geo Test Improvements

## Description

* Extracted post recency filtering logic into a utility function (`filterByRecency`) for cleaner and reusable filtering.
* Improved test script for `geo.js` by comparing calculated Haversine distance with an expected real-world value.
* Added error handling for undefined or empty `results` from the Geoapify API to avoid runtime errors.

## Milestones

* Post filtering logic modularized
* More robust geo-location testing
* Safer external API usage with defensive checks

## Resources

* https://www.geoapify.com/api/geocoding-api/
* Google Maps used to verify distance between Menlo Park and San Francisco

## Test Plan

* Manually tested `filterByRecency` across all filter values (last week, last month, none)
* Verified that Haversine distance output matches ~45km between Menlo Park and San Francisco (±5km tolerance)
* Handled cases where `data.results` is undefined or empty

*Edge Cases Tested:*
* Misspelled or missing locations
* Empty posts array
* Extremely old or future post timestamps
