### PR TITLE
Tc2/iteration/traversal to find neighbors

### DIFF
--- a/backend/routes/recommendation.js
+++ b/backend/routes/recommendation.js
@@ -6,6 +6,9 @@ const { logInteraction } = require('../services/interactions/interaction');
 const {
   getRecommendationInput,
 } = require('../controllers/recommendation.controller');
+const {
+  getCollaborativeRecommendations,
+} = require('../services/recommendation/collabRecommender');
 
 //log user interaction
 router.post('/interaction', checkAuth, async (req, res) => {
@@ -22,6 +25,21 @@ router.post('/interaction', checkAuth, async (req, res) => {
 });
 
 //get recommendation input
-router.get('/:userId',checkAuth, getRecommendationInput);
+router.get('/:userId', checkAuth, getRecommendationInput);
+
+//get collaborative recommendations
+router.get('/collaborative/:userId', checkAuth, async (req, res) => {
+  const userId = req.session.userId;
+  if (!userId) {
+    return res.status(400).json({ error: ERROR_CODES.NOT_AUTHORIZED });
+  }
+  const user = await prisma.user.findUnique({
+    where: {
+      id: userId,
+    },
+  });
+  const posts = await getCollaborativeRecommendations(userId, user.interests);
+  res.status(200).json(posts);
+});
 
 module.exports = router;

--- a/backend/services/recommendation/collabGraph.js
+++ b/backend/services/recommendation/collabGraph.js
@@ -1,4 +1,9 @@
 const { getAllInteractions } = require('../interactions/interaction');
+/**
+ * Builds the interaction graph for the recommendation service
+ * @returns {Promise<{userToPosts: Map<string, Set<string>>, postToUsers: Map<string, Set<string>>}>}
+ *
+ */
 
 async function buildInteractionGraph() {
   const interactions = await getAllInteractions();

--- a/backend/services/recommendation/collabRecommender.js
+++ b/backend/services/recommendation/collabRecommender.js
@@ -1,0 +1,71 @@
+const { buildInteractionGraph } = require('./collabGraph');
+const { getInteractions } = require('../interactions/interaction');
+const { getDomainScore } = require('./categoryClusters');
+
+async function getCollaborativeRecommendations(userId, userInterests) {
+  const { userToPosts, postToUsers } = await buildInteractionGraph();
+  const seenPostIds = new Set();
+  const visited = new Set();
+  const queue = [{ userId: parseInt(userId), depth: 0 }];
+  const postScores = new Map();
+
+  const { likedPosts, reviewedPosts, viewedPosts } =
+    await getInteractions(userId);
+  [...likedPosts, ...reviewedPosts, ...viewedPosts].forEach((interaction) => {
+    seenPostIds.add(interaction.postId);
+  });
+
+  visited.add(parseInt(userId));
+
+  const MAX_DEPTH = 3;
+
+  while (queue.length > 0) {
+    const { userId: currentUserId, depth } = queue.shift();
+    if (depth > MAX_DEPTH) {
+      continue;
+    }
+    const postIds = userToPosts.get(currentUserId) || [];
+
+    for (const postId of postIds) {
+      const users = postToUsers.get(postId) || [];
+
+      for (const neighborUserId of users) {
+        if (!visited.has(neighborUserId)) {
+          visited.add(neighborUserId);
+          queue.push({ userId: neighborUserId, depth: depth + 1 });
+        }
+      }
+    }
+
+    const posts = userToPosts.get(currentUserId) || [];
+    for (const postId of posts) {
+      if (seenPostIds.has(postId)) {
+        continue;
+      }
+
+      const baseScore = 1 / (depth + 1);
+      const oldScore = postScores.get(postId) || 0;
+      postScores.set(postId, oldScore + baseScore);
+    }
+  }
+  const postIds = [...postScores.keys()];
+  const posts = await prisma.post.findMany({
+    where: {
+      id: { in: postIds },
+    },
+  });
+  const enriched = posts.map((post) => {
+    let domainScore = 0;
+    for (const interest of userInterests) {
+      domainScore += getDomainScore(interest, post.category);
+    }
+    return {
+      ...post,
+      score: postScores.get(post.id) + domainScore,
+    };
+  });
+
+  return enriched.sort((a, b) => b.score - a.score).slice(0, 10);
+}
+
+module.exports = { getCollaborativeRecommendations };

--- a/backend/services/recommendation/collabRecommender.js
+++ b/backend/services/recommendation/collabRecommender.js
@@ -2,6 +2,13 @@ const { buildInteractionGraph } = require('./collabGraph');
 const { getInteractions } = require('../interactions/interaction');
 const { getDomainScore } = require('./categoryClusters');
 
+/**
+ * Generates collaborative recommendations for a user based on their interactions with other users and posts.
+ * @param {*} userId - user id of the user to generate recommendations for
+ * @param {*} userInterests - interests of the user to generate recommendations for
+ * @returns - list of recommended posts for the user and their scores
+ */
+
 async function getCollaborativeRecommendations(userId, userInterests) {
   const { userToPosts, postToUsers } = await buildInteractionGraph();
   const seenPostIds = new Set();

--- a/backend/services/recommendation/trending.js
+++ b/backend/services/recommendation/trending.js
@@ -3,7 +3,7 @@ const { InteractionType } = require('../../generated/prisma');
 /**
  * Get the trending posts
  * @param {*} prisma  - Prisma client
- * @returns          - List of trending post ids
+ * @returns - List of trending post ids
  */
 async function trending(prisma) {
   const trendingLimit = new Date(Date.now() - 1000 * 60 * 60 * 24 * 7);


### PR DESCRIPTION
## Description

This pull request adds the **BFS traversal logic** to power collaborative filtering in our SkillSwap recommendation engine.

 Included in this PR:
- Traverse the user-post interaction graph from the current user
- Use BFS to find neighbor users who share post interactions
- Track depth (hop count) from the root user and limit to depth 3 for performance
- For each neighbor user:
  - Gather posts they interacted with (LIKED, REVIEWED, VIEWED)
  - Filter out posts already seen by the root user
  - Score each post with: `score = 1 / (depth + 1)`
  - Add boost for category domain match against root user's interests

 Not included in this PR (to be done in follow-ups):
- Combining these scores with content-based signals (handled in hybrid layer)
- Frontend integration with new recommendation endpoint

---

## Milestones
- TC#2: Collaborative Filtering via Graph Traversal
- Graph-Based Personalization Infrastructure

---

## Resources
- BFS traversal logic - https://www.geeksforgeeks.org/dsa/breadth-first-search-or-bfs-for-a-graph/
- Category domain match logic reused from `categoryClusters.js`

---

## Test Plan
- Tested locally with logs of:
  - BFS depth tracking
  - Queue processing
  - Post filtering and scoring

Sample Logs:
```bash
visited Set(5) { 1, 3, 6, 2, 10 }
queue: [ { userId: 3, depth: 1 }, { userId: 6, depth: 1 }, ... ]
posts Set(13) { 4, 3, 10, 11, 6, 9, ... }
